### PR TITLE
Implement Accent-Ignoring Search for Spells

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-c676b6d3'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.trae30ecf28"
+    "revision": "0.37376si9d2o"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/src/components/molecules/SpellAditionModal/index.tsx
+++ b/src/components/molecules/SpellAditionModal/index.tsx
@@ -4,7 +4,6 @@ import { initialSpell } from "@/constants";
 import { showToast } from "@/providers";
 import { Character, Spell } from "@/types";
 import AddIcon from "@mui/icons-material/Add";
-import BlurOnIcon from "@mui/icons-material/BlurOn";
 import CheckIcon from "@mui/icons-material/Check";
 import { useEffect, useState } from "react";
 import { Buttons, Container, SpellOption, modalStyles } from "./styles";
@@ -15,6 +14,9 @@ type SpellAditionModalProps = {
   setCharacter: (value: Character) => void;
   closeSpellAditionModal: () => void;
 };
+
+const removeAccents = (str: string) =>
+  str.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
 
 export const SpellAditionModal = (props: SpellAditionModalProps) => {
   const { isOpen, character, setCharacter, closeSpellAditionModal } = props;
@@ -27,21 +29,20 @@ export const SpellAditionModal = (props: SpellAditionModalProps) => {
   const filteredSpells = search
     ? spells
         .filter((spell) =>
-          spell.name.toLowerCase().includes(search.toLowerCase())
+          removeAccents(spell.name.toLowerCase()).includes(
+            removeAccents(search.toLowerCase())
+          )
         )
         .slice(0, 20)
-    : spells.slice(0, 20);
+        .sort((a, b) => a.level - b.level)
+    : spells.slice(0, 20).sort((a, b) => a.level - b.level);
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSearch(event.target.value);
   };
 
-  const alreadyHaveTheSpell = (spellName: string): boolean => {
-    if (selectedSpells?.some((spell) => spell.name === spellName)) {
-      return true;
-    }
-    return false;
-  };
+  const alreadyHaveTheSpell = (spellName: string): boolean =>
+    !!selectedSpells?.some((spell) => spell.name === spellName);
 
   const addSpell = (spellToBeAdded: Spell) => {
     setSelectedSpells([...selectedSpells, spellToBeAdded]);
@@ -75,7 +76,7 @@ export const SpellAditionModal = (props: SpellAditionModalProps) => {
       .then((response) => {
         setSpells(response);
       })
-      .catch((error) => console.log(error));
+      .catch((error) => console.error(error));
   }, []);
 
   return (
@@ -90,13 +91,11 @@ export const SpellAditionModal = (props: SpellAditionModalProps) => {
           onChange={handleInputChange}
         />
 
-        <div className="spell_container">
+        <div className="spell_container flex_ssc">
           {filteredSpells.map((spell: Spell) => (
             <SpellOption key={spell._id} className="flex_csb">
               <div className="flex_csr" style={{ gap: 10 }}>
-                <div className="icon flex_ccc">
-                  <BlurOnIcon />
-                </div>
+                <div className="icon flex_ccc">{spell.level}</div>
                 <p className="name">{spell.name}</p>
               </div>
               <button
@@ -116,10 +115,10 @@ export const SpellAditionModal = (props: SpellAditionModalProps) => {
         </div>
 
         <Buttons className="flex_csr">
-          <button className="cancel" onClick={() => cancelSelection()}>
+          <button className="cancel" onClick={cancelSelection}>
             Cancelar
           </button>
-          <button className="save" onClick={() => saveSpells()}>
+          <button className="save" onClick={saveSpells}>
             Salvar
           </button>
         </Buttons>

--- a/src/components/molecules/SpellAditionModal/index.tsx
+++ b/src/components/molecules/SpellAditionModal/index.tsx
@@ -3,6 +3,7 @@ import { spellsService } from "@/connection/spellsService";
 import { initialSpell } from "@/constants";
 import { showToast } from "@/providers";
 import { Character, Spell } from "@/types";
+import { filterSpells } from "@/utils";
 import AddIcon from "@mui/icons-material/Add";
 import CheckIcon from "@mui/icons-material/Check";
 import { useEffect, useState } from "react";
@@ -14,10 +15,6 @@ type SpellAditionModalProps = {
   setCharacter: (value: Character) => void;
   closeSpellAditionModal: () => void;
 };
-
-const removeAccents = (str: string) =>
-  str.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
-
 export const SpellAditionModal = (props: SpellAditionModalProps) => {
   const { isOpen, character, setCharacter, closeSpellAditionModal } = props;
   const [selectedSpells, setSelectedSpells] = useState<Spell[]>(
@@ -26,16 +23,7 @@ export const SpellAditionModal = (props: SpellAditionModalProps) => {
   const [search, setSearch] = useState("");
   const [spells, setSpells] = useState<Spell[]>([initialSpell]);
 
-  const filteredSpells = search
-    ? spells
-        .filter((spell) =>
-          removeAccents(spell.name.toLowerCase()).includes(
-            removeAccents(search.toLowerCase())
-          )
-        )
-        .slice(0, 20)
-        .sort((a, b) => a.level - b.level)
-    : spells.slice(0, 20).sort((a, b) => a.level - b.level);
+  const filteredSpells = filterSpells(spells, search);
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSearch(event.target.value);

--- a/src/components/molecules/SpellAditionModal/styles.ts
+++ b/src/components/molecules/SpellAditionModal/styles.ts
@@ -13,7 +13,8 @@ export const Container = styled.div`
   .spell_container {
     overflow: auto;
     width: 100%;
-    height: 220px;
+    height: 280px;
+    gap: 4px;
   }
 `;
 
@@ -29,11 +30,15 @@ export const SpellOption = styled.div`
     height: 30px;
     border-radius: 10px;
     background-color: var(--ground);
-    color: var(--basic);
+    color: var(--secundary);
   }
 
   .name {
     font-size: var(--medium);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 185px;
   }
 
   .add {

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -1,0 +1,29 @@
+import { Spell } from "@/types";
+
+export const removeAccents = (str: string) =>
+  str.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+
+export const sortSpellsByLevel = (spells: Spell[]): Spell[] => {
+  return spells.slice(0, 20).sort((a, b) => a.level - b.level);
+};
+
+export const filterSpells = (
+  spells: Spell[],
+  search: string | undefined
+): Spell[] => {
+  if (!search) {
+    return sortSpellsByLevel(spells);
+  }
+
+  const normalizedSearchTerm = removeAccents(search.toLowerCase());
+
+  const matchesSearchTerm = (spell: Spell) =>
+    removeAccents(spell.name.toLowerCase()).includes(normalizedSearchTerm);
+
+  const filtered = spells
+    .filter(matchesSearchTerm)
+    .sort((a, b) => a.level - b.level)
+    .slice(0, 20);
+
+  return filtered;
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from "./ProtectedRoute";
 export * from "./calculations";
 export * from "./dices";
+export * from "./filters";
 


### PR DESCRIPTION
Enhance the spell search functionality by implementing a feature that disregards accents. This improvement aims to provide users with a more inclusive and flexible search experience, enabling them to find spells regardless of accent marks in their names.

